### PR TITLE
fix: use hex utils to get the byte array in ByteBuffer

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/HexUtils.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/HexUtils.java
@@ -10,6 +10,10 @@ public class HexUtils {
   }
 
   public static String getHex(ByteBuffer buffer) {
+    return getHex(getBytes(buffer));
+  }
+
+  public static byte[] getBytes(ByteBuffer buffer) {
     // Mark the buffer so that we can reset it later.
     buffer.mark();
     try {
@@ -17,7 +21,7 @@ public class HexUtils {
       buffer.position(0);
       byte[] bytes = new byte[buffer.remaining()];
       buffer.get(bytes);
-      return getHex(bytes);
+      return bytes;
     } finally {
       // Always reset the mark.
       buffer.reset();

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreator.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.hypertrace.core.datamodel.AttributeValue;
+import org.hypertrace.core.datamodel.shared.HexUtils;
 
 public class AttributeValueCreator {
 
@@ -27,9 +28,7 @@ public class AttributeValueCreator {
   public static AttributeValue createFromByteBuffers(Set<ByteBuffer> values) {
     List<String> list = new ArrayList<>();
     values.forEach(value -> {
-      byte[] buf = new byte[value.remaining()];
-      value.get(buf);
-      list.add(new String(buf));
+      list.add(new String(HexUtils.getBytes(value)));
     });
     return AttributeValue.newBuilder().setValueList(list).build();
   }

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
@@ -174,8 +174,10 @@ public class StructuredTraceBuilder {
     }
     StructuredTrace structuredTrace = build();
     long execEndTime = System.currentTimeMillis();
-    LOGGER.debug("Generated structuredTrace from events list in {} ms. Output = {}",
-        (execEndTime - execStartTime), structuredTrace);
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Generated structuredTrace from events list in {} ms. Output = {}",
+          (execEndTime - execStartTime), structuredTrace);
+    }
     return structuredTrace;
   }
 
@@ -339,16 +341,24 @@ public class StructuredTraceBuilder {
       if (!eventRef.getTraceId().equals(traceId)) {
         //either this is an incomplete trace
         //or this referenced event belongs to another trace as of now
-        LOGGER.debug(
-            "Skipping referenced event since it belongs to another trace. EventRef.TraceId = {}  event.TraceId={}",
-            HexUtils.getHex(eventRef.getTraceId()), HexUtils.getHex(traceId));
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug(
+              "Skipping referenced event since it belongs to another trace. EventRef.TraceId = {}  event.TraceId={}",
+              HexUtils.getHex(eventRef.getTraceId()),
+              HexUtils.getHex(traceId)
+          );
+        }
 
         continue;
       }
       if (!eventMap.containsKey(eventRef.getEventId())) {
-        LOGGER.debug(
-            "Referenced eventId:{} is not part of the Trace {}. May be partial trace. ",
-            HexUtils.getHex(eventRef.getEventId()), HexUtils.getHex(eventRef.getTraceId()));
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug(
+              "Referenced eventId:{} is not part of the Trace {}. May be partial trace.",
+              HexUtils.getHex(eventRef.getEventId()),
+              HexUtils.getHex(eventRef.getTraceId())
+          );
+        }
         isPartialTrace = true;
         missingEventIdSet.add(eventRef.getEventId());
         //TODO: consider creating an empty event node?

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/HexUtilsTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/HexUtilsTest.java
@@ -1,0 +1,35 @@
+package org.hypertrace.core.datamodel.shared;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+public class HexUtilsTest {
+  @Test
+  public void testGetHex() {
+    String testString = "\u0001\u0002\u0003\u0004";
+    ByteBuffer byteBuffer = ByteBuffer.wrap(testString.getBytes());
+
+    assertEquals("01020304", HexUtils.getHex(byteBuffer));
+    // The first call should not make sure to reset the position of the buffer to 0.
+    assertEquals("01020304", HexUtils.getHex(byteBuffer));
+  }
+
+  @Test
+  public void testGetBytes() {
+    String testString = "\u0001\u0002\u0003\u0004";
+    ByteBuffer byteBuffer = ByteBuffer.wrap(testString.getBytes());
+
+    byte[] expectedBytes = new byte[] {1, 2, 3, 4};
+    compareByteArrays(expectedBytes, HexUtils.getBytes(byteBuffer));
+    // The first call should not make sure to reset the position of the buffer to 0.
+    compareByteArrays(expectedBytes, HexUtils.getBytes(byteBuffer));
+  }
+
+  private void compareByteArrays(byte[] expectedBytes, byte[] actualBytes) {
+    for (int i = 0; i < expectedBytes.length; i++) {
+      assertEquals(expectedBytes[i], actualBytes[i]);
+    }
+  }
+}

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/HexUtilsTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/HexUtilsTest.java
@@ -12,7 +12,8 @@ public class HexUtilsTest {
     ByteBuffer byteBuffer = ByteBuffer.wrap(testString.getBytes());
 
     assertEquals("01020304", HexUtils.getHex(byteBuffer));
-    // The first call should not make sure to reset the position of the buffer to 0.
+    // The first call should make sure to reset the position of the buffer to 0. We should get back
+    // a value equal to the first call if we make the call again.
     assertEquals("01020304", HexUtils.getHex(byteBuffer));
   }
 
@@ -23,7 +24,8 @@ public class HexUtilsTest {
 
     byte[] expectedBytes = new byte[] {1, 2, 3, 4};
     compareByteArrays(expectedBytes, HexUtils.getBytes(byteBuffer));
-    // The first call should not make sure to reset the position of the buffer to 0.
+    // The first call should make sure to reset the position of the buffer to 0. We should get back
+    // a value equal to the first call if we make the call again.
     compareByteArrays(expectedBytes, HexUtils.getBytes(byteBuffer));
   }
 

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreatorTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreatorTest.java
@@ -24,7 +24,8 @@ public class AttributeValueCreatorTest {
     AttributeValue attributeValue = AttributeValueCreator.createFromByteBuffers(byteBufferSet);
     assertEquals(List.of(testString1, testString2), attributeValue.getValueList());
 
-    // Calling AttributeValueCreator.createFromByteBuffers() should result in the same value.
+    // Calling AttributeValueCreator.createFromByteBuffers() should equal the same value from the
+    // first call.
     AttributeValue attributeValue2 = AttributeValueCreator.createFromByteBuffers(byteBufferSet);
     assertEquals(List.of(testString1, testString2), attributeValue2.getValueList());
   }

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreatorTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/AttributeValueCreatorTest.java
@@ -1,0 +1,31 @@
+package org.hypertrace.core.datamodel.shared.trace;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.ByteBuffer;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.hypertrace.core.datamodel.AttributeValue;
+import org.junit.jupiter.api.Test;
+
+public class AttributeValueCreatorTest {
+  @Test
+  public void testCreateFromByteBuffers() {
+    String testString1 = "\u0001\u0002\u0003\u0004";
+    String testString2 = "\u0005\u0006\u0007\u0008";
+
+    ByteBuffer byteBuffer1 = ByteBuffer.wrap(testString1.getBytes());
+    ByteBuffer byteBuffer2 = ByteBuffer.wrap(testString2.getBytes());
+
+    LinkedHashSet<ByteBuffer> byteBufferSet = new LinkedHashSet<>();
+    byteBufferSet.add(byteBuffer1);
+    byteBufferSet.add(byteBuffer2);
+
+    AttributeValue attributeValue = AttributeValueCreator.createFromByteBuffers(byteBufferSet);
+    assertEquals(List.of(testString1, testString2), attributeValue.getValueList());
+
+    // Calling AttributeValueCreator.createFromByteBuffers() should result in the same value.
+    AttributeValue attributeValue2 = AttributeValueCreator.createFromByteBuffers(byteBufferSet);
+    assertEquals(List.of(testString1, testString2), attributeValue2.getValueList());
+  }
+}


### PR DESCRIPTION
This will also fix issue with empty event id in event ref list. This was caused by AttributeValueCreator.createFromByteBuffers() directly walking throught the ByteBuffer which moves the byte cursor in the buffer and does not reset.