### PR TITLE
Add fields in GRPC event

### DIFF
--- a/data-model/src/main/avro/Event.avdl
+++ b/data-model/src/main/avro/Event.avdl
@@ -3,7 +3,7 @@ protocol EventProtocol {
   import idl "Metrics.avdl";
   import idl "Attributes.avdl";
   import idl "eventfields/http/Http.avdl";
-  import idl "eventfields/grpc/Grpc.avdl";
+  import idl "eventfields/grpc/Rpc.avdl";
   import idl "eventfields/sql/Sql.avdl";
   import idl "eventfields/jaeger/JaegerFields.avdl";
 
@@ -58,5 +58,8 @@ protocol EventProtocol {
     union { null, org.hypertrace.core.datamodel.eventfields.sql.Sql } sql = null;
 
     union { null, string } service_name = null;
+
+    // Rpc attributes for service, method and system corresponding to Otel tags
+    union { null, org.hypertrace.core.datamodel.eventfields.rpc.Rpc } rpc = null;
   }
 }

--- a/data-model/src/main/avro/Event.avdl
+++ b/data-model/src/main/avro/Event.avdl
@@ -3,7 +3,8 @@ protocol EventProtocol {
   import idl "Metrics.avdl";
   import idl "Attributes.avdl";
   import idl "eventfields/http/Http.avdl";
-  import idl "eventfields/grpc/Rpc.avdl";
+  import idl "eventfields/grpc/Grpc.avdl";
+  import idl "eventfields/rpc/Rpc.avdl";
   import idl "eventfields/sql/Sql.avdl";
   import idl "eventfields/jaeger/JaegerFields.avdl";
 

--- a/data-model/src/main/avro/eventfields/grpc/Grpc.avdl
+++ b/data-model/src/main/avro/eventfields/grpc/Grpc.avdl
@@ -7,6 +7,9 @@ protocol GrpcProtocol {
     union { null, string } body = null;
     int size = 0;
     map<string> metadata = {};
+    union { null, string } service = null;
+    union { null, string } path = null;
+    union { null, string } url = null;
   }
 
   record Response {

--- a/data-model/src/main/avro/eventfields/grpc/Grpc.avdl
+++ b/data-model/src/main/avro/eventfields/grpc/Grpc.avdl
@@ -1,5 +1,14 @@
 @namespace("org.hypertrace.core.datamodel.eventfields.grpc")
 protocol GrpcProtocol {
+  record RequestMetadata {
+    union { null, string } authority = null;
+    union { null, string } content_type = null;
+    union { null, string } path = null;
+    union { null, string } x_forwarded_for = null;
+    union { null, string } user_agent = null;
+    map<string> other_metadata = {};
+  }
+
   record Request {
     union { null, string } method = null;
     union { null, string } host_port = null;
@@ -7,9 +16,13 @@ protocol GrpcProtocol {
     union { null, string } body = null;
     int size = 0;
     map<string> metadata = {};
-    union { null, string } service = null;
-    union { null, string } path = null;
-    union { null, string } url = null;
+
+    union { null, RequestMetadata } request_metadata = null;
+  }
+
+  record ResponseMetadata {
+    union { null, string } content_type = null;
+    map<string> other_metadata = {};
   }
 
   record Response {
@@ -20,6 +33,8 @@ protocol GrpcProtocol {
     union { null, string } error_name = null;
     union { null, string } error_message = null;
     map<string> metadata = {};
+
+    union { null, ResponseMetadata } response_metadata = null;
   }
 
   record Grpc {

--- a/data-model/src/main/avro/eventfields/rpc/Rpc.avdl
+++ b/data-model/src/main/avro/eventfields/rpc/Rpc.avdl
@@ -1,0 +1,8 @@
+@namespace("org.hypertrace.core.datamodel.eventfields.rpc")
+protocol RpcProtocol {
+  record Rpc {
+    union { null, string } system = null;
+    union { null, string } service = null;
+    union { null, string } method = null;
+  }
+}


### PR DESCRIPTION
Grpc request path can be broken into following parts:
$package.$service/$method
method field in event represents $method
service field in event represents $package.$service
path field in the event represents $package.$service/$method
url field in the event is the url for http/2 call for grpc

Based on: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/rpc.md