### PR TITLE
Performance optimization : Use id as key in hash maps and hash sets instead of whole event or entity

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -54,10 +54,16 @@ public class StructuredTraceGraph {
     return graph;
   }
 
+  /**
+   * @return an immutable set containing the root events
+   */
   public Set<Event> getRootEvents() {
     return rootEvents;
   }
 
+  /**
+   * @return an immutable set containing the root entities
+   */
   public Set<Entity> getRootEntities() {
     return rootEntities;
   }
@@ -78,6 +84,9 @@ public class StructuredTraceGraph {
     return parentToChildrenEntities.get(entity.getEntityId());
   }
 
+  /**
+   * @return an immutable map of entity ids to entities
+   */
   public Map<String, Entity> getEntityMap() {
     return entityMap;
   }
@@ -107,8 +116,8 @@ public class StructuredTraceGraph {
         Integer targetIndex = edge.getTgtIndex();
         Event parentEvent = events.get(sourceIndex);
         Event childEvent = events.get(targetIndex);
-        parentToChildrenEvents.putIfAbsent(parentEvent.getEventId(), new ArrayList<>());
-        parentToChildrenEvents.get(parentEvent.getEventId()).add(childEvent);
+        parentToChildrenEvents.computeIfAbsent(parentEvent.getEventId(), k -> new ArrayList<>())
+            .add(childEvent);
         childToParentEvents.put(childEvent.getEventId(), parentEvent);
       }
     }
@@ -125,10 +134,10 @@ public class StructuredTraceGraph {
         Integer targetIndex = entityEdge.getTgtIndex();
         Entity parentEntity = entities.get(sourceIndex);
         Entity childEntity = entities.get(targetIndex);
-        parentToChildrenEntities.putIfAbsent(parentEntity.getEntityId(), new ArrayList<>());
-        parentToChildrenEntities.get(parentEntity.getEntityId()).add(childEntity);
-        childToParentEntities.putIfAbsent(childEntity.getEntityId(), new ArrayList<>());
-        childToParentEntities.get(childEntity.getEntityId()).add(parentEntity);
+        parentToChildrenEntities.computeIfAbsent(parentEntity.getEntityId(), k -> new ArrayList<>())
+            .add(childEntity);
+        childToParentEntities.computeIfAbsent(childEntity.getEntityId(), k -> new ArrayList<>())
+            .add(parentEntity);
       }
     }
   }
@@ -162,7 +171,9 @@ public class StructuredTraceGraph {
         .collect(Collectors.toUnmodifiableSet());
   }
 
-
+  /**
+   * @return an immutable map of event ids to events
+   */
   public Map<ByteBuffer, Event> getEventMap() {
     return eventMap;
   }

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -118,10 +118,6 @@ public class StructuredTraceGraph {
       return;
     }
 
-    for (Entity entity : entities) {
-      entityMap.put(entity.getEntityId(), entity);
-    }
-
     List<Edge> entityEdges = trace.getEntityEdgeList();
     if (entityEdges != null) {
       for (Edge entityEdge : trace.getEntityEdgeList()) {

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -1,13 +1,13 @@
 package org.hypertrace.core.datamodel.shared;
 
-import com.google.common.collect.ImmutableSet;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.hypertrace.core.datamodel.Edge;
 import org.hypertrace.core.datamodel.Entity;
@@ -20,22 +20,20 @@ import org.hypertrace.core.datamodel.StructuredTrace;
  */
 public class StructuredTraceGraph {
 
-  private final Map<ByteBuffer, Event> eventMap;
-  private final Map<String, Entity> entityMap;
-
   /* there could be multiple roots for partial trace and incomplete instrumented app spans */
-  private final Map<Event, List<Event>> parentToChildrenEvents;
-  private final Map<Event, Event> childToParentEvents;
+  private final Map<ByteBuffer, List<Event>> parentToChildrenEvents;
+  private final Map<ByteBuffer, Event> childToParentEvents;
   /* entity have many-to-many relationship */
-  private final Map<Entity, List<Entity>> parentToChildrenEntities;
-  private final Map<Entity, List<Entity>> childToParentEntities;
+  private final Map<String, List<Entity>> parentToChildrenEntities;
+  private final Map<String, List<Entity>> childToParentEntities;
 
+  /* these containers should be unmodifiable after initialization as we're exposing them via getters */
+  private Map<ByteBuffer, Event> eventMap;
+  private Map<String, Entity> entityMap;
   private Set<Event> rootEvents;
   private Set<Entity> rootEntities;
 
   private StructuredTraceGraph() {
-    this.eventMap = new HashMap<>();
-    this.entityMap = new HashMap<>();
     this.childToParentEntities = new HashMap<>();
     this.parentToChildrenEntities = new HashMap<>();
     this.childToParentEvents = new HashMap<>();
@@ -48,6 +46,8 @@ public class StructuredTraceGraph {
    */
   public static StructuredTraceGraph createGraph(StructuredTrace trace) {
     StructuredTraceGraph graph = new StructuredTraceGraph();
+    graph.buildEventMap(trace);
+    graph.buildEntityMap(trace);
     graph.buildParentChildRelationship(trace);
     graph.buildRootEvents(trace);
     graph.buildRootEntities(trace);
@@ -55,31 +55,41 @@ public class StructuredTraceGraph {
   }
 
   public Set<Event> getRootEvents() {
-    return ImmutableSet.copyOf(rootEvents);
+    return rootEvents;
   }
 
   public Set<Entity> getRootEntities() {
-    return ImmutableSet.copyOf(rootEntities);
+    return rootEntities;
   }
 
   public Event getParentEvent(Event event) {
-    return childToParentEvents.get(event);
+    return childToParentEvents.get(event.getEventId());
   }
 
   public List<Entity> getParentEntities(Entity entity) {
-    return childToParentEntities.get(entity);
+    return childToParentEntities.get(entity.getEntityId());
   }
 
   public List<Event> getChildrenEvents(Event event) {
-    return parentToChildrenEvents.get(event);
+    return parentToChildrenEvents.get(event.getEventId());
   }
 
   public List<Entity> getChildrenEntities(Entity entity) {
-    return parentToChildrenEntities.get(entity);
+    return parentToChildrenEntities.get(entity.getEntityId());
   }
 
   public Map<String, Entity> getEntityMap() {
     return entityMap;
+  }
+
+  private void buildEventMap(StructuredTrace trace) {
+    eventMap = trace.getEventList().stream()
+        .collect(Collectors.toUnmodifiableMap(Event::getEventId, Function.identity()));
+  }
+
+  private void buildEntityMap(StructuredTrace trace) {
+    entityMap = trace.getEntityList().stream()
+        .collect(Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity()));
   }
 
   private void buildParentChildRelationship(StructuredTrace trace) {
@@ -90,11 +100,6 @@ public class StructuredTraceGraph {
     }
 
     List<Entity> entities = trace.getEntityList();
-
-    for (Event event : events) {
-      eventMap.put(event.getEventId(), event);
-    }
-
     List<Edge> eventEdges = trace.getEventEdgeList();
     if (eventEdges != null) {
       for (Edge edge : trace.getEventEdgeList()) {
@@ -102,9 +107,9 @@ public class StructuredTraceGraph {
         Integer targetIndex = edge.getTgtIndex();
         Event parentEvent = events.get(sourceIndex);
         Event childEvent = events.get(targetIndex);
-        parentToChildrenEvents.putIfAbsent(parentEvent, new ArrayList<>());
-        parentToChildrenEvents.get(parentEvent).add(childEvent);
-        childToParentEvents.put(childEvent, parentEvent);
+        parentToChildrenEvents.putIfAbsent(parentEvent.getEventId(), new ArrayList<>());
+        parentToChildrenEvents.get(parentEvent.getEventId()).add(childEvent);
+        childToParentEvents.put(childEvent.getEventId(), parentEvent);
       }
     }
 
@@ -124,29 +129,41 @@ public class StructuredTraceGraph {
         Integer targetIndex = entityEdge.getTgtIndex();
         Entity parentEntity = entities.get(sourceIndex);
         Entity childEntity = entities.get(targetIndex);
-        parentToChildrenEntities.putIfAbsent(parentEntity, new ArrayList<>());
-        parentToChildrenEntities.get(parentEntity).add(childEntity);
-        childToParentEntities.putIfAbsent(childEntity, new ArrayList<>());
-        childToParentEntities.get(childEntity).add(parentEntity);
+        parentToChildrenEntities.putIfAbsent(parentEntity.getEntityId(), new ArrayList<>());
+        parentToChildrenEntities.get(parentEntity.getEntityId()).add(childEntity);
+        childToParentEntities.putIfAbsent(childEntity.getEntityId(), new ArrayList<>());
+        childToParentEntities.get(childEntity.getEntityId()).add(parentEntity);
       }
     }
   }
 
   private void buildRootEvents(StructuredTrace trace) {
-    // build the root entities
-    rootEvents = new HashSet<>(trace.getEventList());
+    // build the root event ids
+    Set<ByteBuffer> rootEventIds = trace.getEventList().stream().map(Event::getEventId)
+        .collect(Collectors.toSet());
+
     // remove all the children, and what's remaining are the events without children
     // we will consider these are roots, including the ones that are standalone
-    for (List<Event> childEvents : parentToChildrenEvents.values()) {
-      rootEvents.removeAll(childEvents);
-    }
+    Set<ByteBuffer> childrenEventIds = parentToChildrenEvents.values().stream()
+        .flatMap(l -> l.stream().map(Event::getEventId)).collect(Collectors.toSet());
+    rootEventIds.removeAll(childrenEventIds);
+
+    rootEvents = rootEventIds.stream().map(eventMap::get).collect(Collectors.toUnmodifiableSet());
   }
 
   private void buildRootEntities(StructuredTrace trace) {
-    rootEntities = new HashSet<>(trace.getEntityList());
-    for (List<Entity> childEntities : parentToChildrenEntities.values()) {
-      rootEntities.removeAll(childEntities);
-    }
+    // build the root entity ids
+    Set<String> rootEntityIds = trace.getEntityList().stream().map(Entity::getEntityId)
+        .collect(Collectors.toSet());
+
+    // remove all the children, and what's remaining are the entities without children
+    // we will consider these are roots, including the ones that are standalone
+    Set<String> childrenEntityIds = parentToChildrenEntities.values().stream()
+        .flatMap(l -> l.stream().map(Entity::getEntityId)).collect(Collectors.toSet());
+    rootEntityIds.removeAll(childrenEntityIds);
+
+    rootEntities = rootEntityIds.stream().map(entityMap::get)
+        .collect(Collectors.toUnmodifiableSet());
   }
 
 
@@ -157,7 +174,7 @@ public class StructuredTraceGraph {
   public Map<ByteBuffer, ByteBuffer> getChildIdsToParentIds() {
     return childToParentEvents.entrySet().stream()
         .collect(Collectors.toMap(
-            e -> getEventId(e.getKey()),
+            Entry::getKey,
             e -> getEventId(e.getValue())
         ));
   }
@@ -165,7 +182,7 @@ public class StructuredTraceGraph {
   public Map<ByteBuffer, List<ByteBuffer>> getParentToChildEventIds() {
     return parentToChildrenEvents.entrySet().stream()
         .collect(Collectors.toMap(
-            e -> getEventId(e.getKey()),
+            Entry::getKey,
             e -> e.getValue().stream().map(this::getEventId).collect(Collectors.toList()))
         );
   }

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
@@ -1,0 +1,190 @@
+package org.hypertrace.core.datamodel.shared;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.hypertrace.core.datamodel.Attributes;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.EventRef;
+import org.hypertrace.core.datamodel.EventRefType;
+import org.hypertrace.core.datamodel.Metrics;
+import org.hypertrace.core.datamodel.RawSpan;
+import org.hypertrace.core.datamodel.StructuredTrace;
+import org.hypertrace.core.datamodel.shared.trace.StructuredTraceAssert;
+import org.hypertrace.core.datamodel.shared.trace.StructuredTraceBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class StructuredTraceGraphTest {
+
+  private static final String CUSTOMER_ID = "customer_id";
+
+  @Mock
+  private StructuredTrace trace;
+  private List<Event> events;
+  private List<Entity> entities;
+  private List<Edge> eventEdges;
+  private List<Edge> entityEdges;
+  private StructuredTraceGraph graph;
+  private Map<ByteBuffer, Event> expectedEventMap;
+  private Map<ByteBuffer, ByteBuffer> childToParentIds;
+
+  @BeforeEach
+  void setup() {
+    /* to reset the mocks for each @Test */
+    MockitoAnnotations.initMocks(this);
+    events = new ArrayList<>();
+    entities = new ArrayList<>();
+    eventEdges = new ArrayList<>();
+    entityEdges = new ArrayList<>();
+    expectedEventMap = new HashMap<>();
+    childToParentIds = new HashMap<>();
+    setupEventAndEntityMocks(4);
+  }
+
+  @Test
+  void test_createGraph_validInput_shouldCreateCorrectGraph() {
+    int rootIndex1 = 0;
+    int rootIndex2 = 1;
+    int sourceIdx1 = rootIndex1;
+    int targetIdx1 = 2;
+    int targetIdx2 = 3;
+    addEdges(sourceIdx1, targetIdx1, eventEdges);
+    addEdges(sourceIdx1, targetIdx1, entityEdges);
+    addEdges(targetIdx1, targetIdx2, eventEdges);
+    addEdges(targetIdx1, targetIdx2, entityEdges);
+    childToParentIds.put(events.get(targetIdx1).getEventId(), events.get(sourceIdx1).getEventId());
+    childToParentIds.put(events.get(targetIdx2).getEventId(), events.get(targetIdx1).getEventId());
+
+    when(trace.getEventEdgeList()).thenReturn(eventEdges);
+    when(trace.getEntityEdgeList()).thenReturn(entityEdges);
+
+    Set<Event> expectedRootEvents = Sets.newHashSet(events.get(rootIndex1), events.get(rootIndex2));
+    Set<Entity> expectedRootEntities =
+        Sets.newHashSet(entities.get(rootIndex1), entities.get(rootIndex2));
+
+    graph = StructuredTraceGraph.createGraph(trace);
+    assertEquals(expectedRootEntities, graph.getRootEntities());
+    assertEquals(expectedRootEvents, graph.getRootEvents());
+    assertEquals(events.get(sourceIdx1), graph.getParentEvent(events.get(targetIdx1)));
+    assertEquals(Lists.newArrayList(entities.get(sourceIdx1)),
+        graph.getParentEntities(entities.get(targetIdx1)));
+    List<Entity> root1Children = graph.getChildrenEntities(entities.get(rootIndex1));
+    assertEquals(Lists.newArrayList(entities.get(targetIdx1)), root1Children);
+    assertEquals(expectedEventMap, graph.getEventMap());
+    assertEquals(childToParentIds, graph.getChildIdsToParentIds());
+  }
+
+  private void setupEventAndEntityMocks(int totalEvent) {
+    for (int index = 0; index < totalEvent; index++) {
+      Event event = mock(Event.class);
+      when(event.getEventId())
+          .thenReturn(ByteBuffer.wrap(String.valueOf(index).getBytes()));
+      events.add(event);
+
+      expectedEventMap.put(event.getEventId(), event);
+      Entity entity = mock(Entity.class);
+      when(entity.getEntityId())
+          .thenReturn(String.valueOf(index));
+      entities.add(entity);
+    }
+    when(trace.getEventList()).thenReturn(events);
+    when(trace.getEntityList()).thenReturn(entities);
+  }
+
+  private void addEdges(int sourceIdx, int targetIdx, Collection<Edge> collectionToAdd) {
+    Edge edge = mock(Edge.class);
+    when(edge.getSrcIndex()).thenReturn(sourceIdx);
+    when(edge.getTgtIndex()).thenReturn(targetIdx);
+    collectionToAdd.add(edge);
+  }
+
+  @Test
+  void testOnMockedEvents() {
+    ByteBuffer traceId = generateRandomId();
+
+    String entityId1 = UUID.randomUUID().toString();
+    Event e1 = getEvent(generateRandomId(), entityId1);
+    Entity entity1 = getEntity(entityId1, "DOCKER_CONTAINER");
+    RawSpan rawSpan1 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+        .setEvent(e1).setEntityList(List.of(entity1)).build();
+
+    String entityId2 = UUID.randomUUID().toString();
+    Event e2 = getEvent(generateRandomId(), entityId2);
+    Entity entity2 = getEntity(entityId2, "K8S_POD");
+    RawSpan rawSpan2 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+        .setEvent(e2).setEntityList(List.of(entity2)).build();
+
+    // Make e2 as child of e1.
+    ByteBuffer eventId1 = e1.getEventId();
+    when(e2.getEventRefList()).thenReturn(Collections.singletonList(
+        EventRef.newBuilder().setEventId(eventId1).setRefType(EventRefType.CHILD_OF)
+            .setTraceId(traceId).build()));
+
+    StructuredTrace trace = StructuredTraceBuilder
+        .buildStructuredTraceFromRawSpans(List.of(rawSpan1, rawSpan2),
+            traceId,
+            CUSTOMER_ID);
+
+    assertEquals(traceId, trace.getTraceId());
+    assertEquals(CUSTOMER_ID, trace.getCustomerId());
+    assertEquals(2, trace.getEventList().size());
+    assertEquals(2, trace.getEntityList().size());
+
+    StructuredTraceAssert.assertEntityEntityEdge(trace);
+    StructuredTraceAssert.assertEventEventEdge(trace);
+    StructuredTraceAssert.assertEntityEventEdges(trace);
+
+    StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
+    assertEquals(2, graph.getEventMap().size());
+    assertEquals(1, graph.getRootEntities().size());
+    assertEquals(1, graph.getRootEvents().size());
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertEquals(e1, graph.getParentEvent(e2));
+  }
+
+  private ByteBuffer generateRandomId() {
+    return ByteBuffer.wrap(UUID.randomUUID().toString().getBytes());
+  }
+
+  private Entity getEntity(String entityId, String entityType) {
+    return Entity.newBuilder().setEntityId(entityId).setEntityType(entityType)
+        .setEntityName(entityId).setCustomerId(CUSTOMER_ID)
+        .setAttributes(Attributes.newBuilder().setAttributeMap(new HashMap<>()).build())
+        .build();
+  }
+
+  private Event getEvent(ByteBuffer eventId, String entityId) {
+    Event e = mock(Event.class);
+    when(e.getEventId()).thenReturn(eventId);
+    when(e.getEntityIdList()).thenReturn(Collections.singletonList(entityId));
+    when(e.getAttributes())
+        .thenReturn(Attributes.newBuilder().setAttributeMap(new HashMap<>()).build());
+    when(e.getEnrichedAttributes())
+        .thenReturn(Attributes.newBuilder().setAttributeMap(new HashMap<>()).build());
+    when(e.getMetrics())
+        .thenReturn(Metrics.newBuilder().setMetricMap(new HashMap<>()).build());
+    return e;
+  }
+
+}

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceAssert.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceAssert.java
@@ -1,0 +1,83 @@
+package org.hypertrace.core.datamodel.shared.trace;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+
+public class StructuredTraceAssert {
+
+  public static void assertEntityEntityEdge(StructuredTrace structuredTrace) {
+    Map<Integer, Entity> indexToEntityMap = new HashMap<>();
+    List<Entity> entities = structuredTrace.getEntityList();
+
+    int index = 0;
+    for (Entity entity : entities) {
+      indexToEntityMap.put(index++, entity);
+    }
+
+    List<Edge> entityEdges = structuredTrace.getEntityEdgeList();
+    // source entity and target entity are different
+    for (Edge edge : entityEdges) {
+      Entity sourceEntity = indexToEntityMap.get(edge.getSrcIndex());
+      Entity targetEntity = indexToEntityMap.get(edge.getTgtIndex());
+
+      assertNotNull(sourceEntity);
+      assertNotNull(targetEntity);
+      assertNotEquals(sourceEntity, targetEntity);
+    }
+  }
+
+  public static void assertEventEventEdge(StructuredTrace structuredTrace) {
+    Map<Integer, Event> indexToEventMap = new HashMap<>();
+    List<Event> events = structuredTrace.getEventList();
+
+    int index = 0;
+    for (Event event : events) {
+      indexToEventMap.put(index++, event);
+    }
+
+    List<Edge> eventEdges = structuredTrace.getEventEdgeList();
+
+    for (Edge edge : eventEdges) {
+      Event srcEvent = indexToEventMap.get(edge.getSrcIndex());
+      Event destEvent = indexToEventMap.get(edge.getTgtIndex());
+
+      assertNotNull(srcEvent);
+      assertNotNull(destEvent);
+      assertNotEquals(srcEvent, destEvent);
+    }
+  }
+
+  public static void assertEntityEventEdges(StructuredTrace structuredTrace) {
+    Map<Integer, Event> indexToEventMap = new HashMap<>();
+    List<Event> events = structuredTrace.getEventList();
+
+    int index = 0;
+    for (Event event : events) {
+      indexToEventMap.put(index++, event);
+    }
+
+    Map<Integer, Entity> indexToEntityMap = new HashMap<>();
+    List<Entity> entities = structuredTrace.getEntityList();
+
+    index = 0;
+    for (Entity entity : entities) {
+      indexToEntityMap.put(index++, entity);
+    }
+
+    for (Edge edge : structuredTrace.getEntityEventEdgeList()) {
+      Entity entity = indexToEntityMap.get(edge.getSrcIndex());
+      Event event = indexToEventMap.get(edge.getTgtIndex());
+
+      assertNotNull(entity);
+      assertNotNull(event);
+    }
+  }
+}


### PR DESCRIPTION
## Description
Currently, at some places in `StructuredTraceGraph`, we're using the whole event (or entity) as the key in hash maps or hash sets, which means every single access(put and get) to these maps involves computing a hash code of the whole event which can be quite expensive. Instead, we can use the event id (or the entity id) as the key which would significantly bring down the cost of accessing an element in the map and thus, bring down the cost of building a `StructuredTraceGraph` as well.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit tests.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
