### PR TITLE
Handle duplicate entities while building StructuredTraceGraph

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -93,12 +93,15 @@ public class StructuredTraceGraph {
 
   private void buildEventMap(StructuredTrace trace) {
     eventMap = trace.getEventList().stream()
-        .collect(Collectors.toUnmodifiableMap(Event::getEventId, Function.identity()));
+        .collect(
+            Collectors.toUnmodifiableMap(Event::getEventId, Function.identity(), (e1, e2) -> e2));
+
   }
 
   private void buildEntityMap(StructuredTrace trace) {
     entityMap = trace.getEntityList().stream()
-        .collect(Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity()));
+        .collect(
+            Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity(), (e1, e2) -> e2));
   }
 
   private void buildParentChildRelationship(StructuredTrace trace) {

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
@@ -61,7 +61,11 @@ class StructuredTraceGraphTest {
   }
 
   @Test
-  void test_createGraph_validInput_shouldCreateCorrectGraph() {
+  void test_createGraph_withValidInput() {
+    createGraph_shouldCreateCorrectGraph();
+  }
+
+  private void createGraph_shouldCreateCorrectGraph() {
     int rootIndex1 = 0;
     int rootIndex2 = 1;
     int sourceIdx1 = rootIndex1;
@@ -185,6 +189,14 @@ class StructuredTraceGraphTest {
     when(e.getMetrics())
         .thenReturn(Metrics.newBuilder().setMetricMap(new HashMap<>()).build());
     return e;
+  }
+
+  @Test
+  void test_createGraph_withDuplicateEntities() {
+    // add duplicate entity
+    entities.add(entities.get(0));
+
+    createGraph_shouldCreateCorrectGraph();
   }
 
 }


### PR DESCRIPTION
## Description
With the [changes in this PR](https://github.com/hypertrace/data-model/pull/14/files#r561034319), we also need to handle duplicate entities in a trace. This PR fixes it.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Added unit test

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
