### PR TITLE
feat: Schema for log event records

### DIFF
--- a/data-model/src/main/avro/RawEventLog.avdl
+++ b/data-model/src/main/avro/RawEventLog.avdl
@@ -1,0 +1,19 @@
+@namespace("org.hypertrace.core.datamodel")
+protocol LogEventRecordsProtocol {
+  import idl "Attributes.avdl";
+
+  record LogEventRecord {
+    string customer_id;
+
+    bytes span_id;
+    bytes trace_id;
+
+    long time_stamp = 0;
+
+    union { null, Attributes } attributes = null;
+  }
+
+  record LogEventRecords {
+    array<LogEventRecord> log_event_records = [];
+  }
+}


### PR DESCRIPTION
This pr adds schema for representing log event records in the ingestion pipeline. 
Draft pr for ingestion changes: https://github.com/hypertrace/hypertrace-ingester/pull/165