### PR TITLE
ci: make ci proceed if unable to publish unit test results

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,6 +54,7 @@ jobs:
      
       - name: Publish Unit Test Results
         uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1.6
+        continue-on-error: true
         if: always()
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Forked PRs are not given permissions to write test results back to the PR, so that step will fail. We can silently proceed and get that behavior for branched PRs with this change. Ref: https://github.com/hypertrace/data-model/pull/20#issuecomment-813660734
