### PR TITLE
Compose StructuredTraceGraph from Entities and events graph

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/SpanAttributeUtils.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/SpanAttributeUtils.java
@@ -20,7 +20,7 @@ import org.hypertrace.core.datamodel.Event;
 public class SpanAttributeUtils {
 
   public static boolean isLeafSpan(StructuredTraceGraph structuredTraceGraph, Event event) {
-    List<Event> childEvents = structuredTraceGraph.getTraceEventsGraph().getChildrenEvents(event);
+    List<Event> childEvents = structuredTraceGraph.getChildrenEvents(event);
     return childEvents == null || childEvents.isEmpty();
   }
 

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/SpanAttributeUtils.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/SpanAttributeUtils.java
@@ -20,7 +20,7 @@ import org.hypertrace.core.datamodel.Event;
 public class SpanAttributeUtils {
 
   public static boolean isLeafSpan(StructuredTraceGraph structuredTraceGraph, Event event) {
-    List<Event> childEvents = structuredTraceGraph.getChildrenEvents(event);
+    List<Event> childEvents = structuredTraceGraph.getTraceEventsGraph().getChildrenEvents(event);
     return childEvents == null || childEvents.isEmpty();
   }
 

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -1,17 +1,5 @@
 package org.hypertrace.core.datamodel.shared;
 
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import org.hypertrace.core.datamodel.Edge;
-import org.hypertrace.core.datamodel.Entity;
-import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 
 /**
@@ -20,187 +8,36 @@ import org.hypertrace.core.datamodel.StructuredTrace;
  */
 public class StructuredTraceGraph {
 
-  /* there could be multiple roots for partial trace and incomplete instrumented app spans */
-  private final Map<ByteBuffer, List<Event>> parentToChildrenEvents;
-  private final Map<ByteBuffer, Event> childToParentEvents;
-  /* entity have many-to-many relationship */
-  private final Map<String, List<Entity>> parentToChildrenEntities;
-  private final Map<String, List<Entity>> childToParentEntities;
+  private TraceEventsGraph traceEventsGraph;
+  private TraceEntitiesGraph traceEntitiesGraph;
 
-  /* these containers should be unmodifiable after initialization as we're exposing them via getters */
-  private Map<ByteBuffer, Event> eventMap;
-  private Map<String, Entity> entityMap;
-  private Set<Event> rootEvents;
-  private Set<Entity> rootEntities;
-
-  private StructuredTraceGraph() {
-    this.childToParentEntities = new HashMap<>();
-    this.parentToChildrenEntities = new HashMap<>();
-    this.childToParentEvents = new HashMap<>();
-    this.parentToChildrenEvents = new HashMap<>();
-  }
-
-  /**
-   * Create the instance with or without the full traversal graph includesFullGraph    Includes
-   * computing the full traversal graph or not
-   */
   public static StructuredTraceGraph createGraph(StructuredTrace trace) {
     StructuredTraceGraph graph = new StructuredTraceGraph();
-    graph.buildEventMap(trace);
-    graph.buildEntityMap(trace);
-    graph.buildParentChildRelationship(trace);
-    graph.buildRootEvents(trace);
-    graph.buildRootEntities(trace);
+    graph.traceEventsGraph = TraceEventsGraph.createGraph(trace);
+    graph.traceEntitiesGraph = TraceEntitiesGraph.createGraph(trace);
+
     return graph;
   }
 
-  /**
-   * @return an immutable set containing the root events
-   */
-  public Set<Event> getRootEvents() {
-    return rootEvents;
+  public static StructuredTraceGraph reCreateTraceEventsGraph(StructuredTrace trace) {
+    StructuredTraceGraph graph = new StructuredTraceGraph();
+    graph.traceEventsGraph = TraceEventsGraph.createGraph(trace);
+
+    return graph;
   }
 
-  /**
-   * @return an immutable set containing the root entities
-   */
-  public Set<Entity> getRootEntities() {
-    return rootEntities;
+  public static StructuredTraceGraph reCreateTraceEntitiesGraph(StructuredTrace trace) {
+    StructuredTraceGraph graph = new StructuredTraceGraph();
+    graph.traceEntitiesGraph = TraceEntitiesGraph.createGraph(trace);
+
+    return graph;
   }
 
-  public Event getParentEvent(Event event) {
-    return childToParentEvents.get(event.getEventId());
+  public TraceEventsGraph getTraceEventsGraph() {
+    return this.traceEventsGraph;
   }
 
-  public List<Entity> getParentEntities(Entity entity) {
-    return childToParentEntities.get(entity.getEntityId());
-  }
-
-  public List<Event> getChildrenEvents(Event event) {
-    return parentToChildrenEvents.get(event.getEventId());
-  }
-
-  public List<Entity> getChildrenEntities(Entity entity) {
-    return parentToChildrenEntities.get(entity.getEntityId());
-  }
-
-  /**
-   * @return an immutable map of entity ids to entities
-   */
-  public Map<String, Entity> getEntityMap() {
-    return entityMap;
-  }
-
-  private void buildEventMap(StructuredTrace trace) {
-    eventMap = trace.getEventList().stream()
-        .collect(
-            Collectors.toUnmodifiableMap(Event::getEventId, Function.identity(), (e1, e2) -> e2));
-
-  }
-
-  private void buildEntityMap(StructuredTrace trace) {
-    entityMap = trace.getEntityList().stream()
-        .collect(
-            Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity(), (e1, e2) -> e2));
-  }
-
-  private void buildParentChildRelationship(StructuredTrace trace) {
-    List<Event> events = trace.getEventList();
-    // there's no graph
-    if (events == null) {
-      return;
-    }
-
-    List<Entity> entities = trace.getEntityList();
-    List<Edge> eventEdges = trace.getEventEdgeList();
-    if (eventEdges != null) {
-      for (Edge edge : trace.getEventEdgeList()) {
-        Integer sourceIndex = edge.getSrcIndex();
-        Integer targetIndex = edge.getTgtIndex();
-        Event parentEvent = events.get(sourceIndex);
-        Event childEvent = events.get(targetIndex);
-        parentToChildrenEvents.computeIfAbsent(parentEvent.getEventId(), k -> new ArrayList<>())
-            .add(childEvent);
-        childToParentEvents.put(childEvent.getEventId(), parentEvent);
-      }
-    }
-
-    // return for now, we don't forsee this is to be null.
-    if (entities == null) {
-      return;
-    }
-
-    List<Edge> entityEdges = trace.getEntityEdgeList();
-    if (entityEdges != null) {
-      for (Edge entityEdge : trace.getEntityEdgeList()) {
-        Integer sourceIndex = entityEdge.getSrcIndex();
-        Integer targetIndex = entityEdge.getTgtIndex();
-        Entity parentEntity = entities.get(sourceIndex);
-        Entity childEntity = entities.get(targetIndex);
-        parentToChildrenEntities.computeIfAbsent(parentEntity.getEntityId(), k -> new ArrayList<>())
-            .add(childEntity);
-        childToParentEntities.computeIfAbsent(childEntity.getEntityId(), k -> new ArrayList<>())
-            .add(parentEntity);
-      }
-    }
-  }
-
-  private void buildRootEvents(StructuredTrace trace) {
-    // build the root event ids
-    Set<ByteBuffer> rootEventIds = trace.getEventList().stream().map(Event::getEventId)
-        .collect(Collectors.toSet());
-
-    // remove all the children, and what's remaining are the events without children
-    // we will consider these are roots, including the ones that are standalone
-    Set<ByteBuffer> childrenEventIds = parentToChildrenEvents.values().stream()
-        .flatMap(l -> l.stream().map(Event::getEventId)).collect(Collectors.toSet());
-    rootEventIds.removeAll(childrenEventIds);
-
-    rootEvents = rootEventIds.stream().map(eventMap::get).collect(Collectors.toUnmodifiableSet());
-  }
-
-  private void buildRootEntities(StructuredTrace trace) {
-    // build the root entity ids
-    Set<String> rootEntityIds = trace.getEntityList().stream().map(Entity::getEntityId)
-        .collect(Collectors.toSet());
-
-    // remove all the children, and what's remaining are the entities without children
-    // we will consider these are roots, including the ones that are standalone
-    Set<String> childrenEntityIds = parentToChildrenEntities.values().stream()
-        .flatMap(l -> l.stream().map(Entity::getEntityId)).collect(Collectors.toSet());
-    rootEntityIds.removeAll(childrenEntityIds);
-
-    rootEntities = rootEntityIds.stream().map(entityMap::get)
-        .collect(Collectors.toUnmodifiableSet());
-  }
-
-  /**
-   * @return an immutable map of event ids to events
-   */
-  public Map<ByteBuffer, Event> getEventMap() {
-    return eventMap;
-  }
-
-  public Map<ByteBuffer, ByteBuffer> getChildIdsToParentIds() {
-    return childToParentEvents.entrySet().stream()
-        .collect(Collectors.toMap(
-            Entry::getKey,
-            e -> getEventId(e.getValue())
-        ));
-  }
-
-  public Map<ByteBuffer, List<ByteBuffer>> getParentToChildEventIds() {
-    return parentToChildrenEvents.entrySet().stream()
-        .collect(Collectors.toMap(
-            Entry::getKey,
-            e -> e.getValue().stream().map(this::getEventId).collect(Collectors.toList()))
-        );
-  }
-
-  private ByteBuffer getEventId(Event event) {
-    if (event == null) {
-      return null;
-    }
-    return event.getEventId();
+  public TraceEntitiesGraph getTraceEntitiesGraph() {
+    return this.traceEntitiesGraph;
   }
 }

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -1,5 +1,11 @@
 package org.hypertrace.core.datamodel.shared;
 
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 
 /**
@@ -38,11 +44,51 @@ public class StructuredTraceGraph {
     return graph;
   }
 
+  public Set<Event> getRootEvents() {
+    return traceEventsGraph.getRootEvents();
+  }
+
+  public Set<Entity> getRootEntities() {
+    return traceEntitiesGraph.getRootEntities();
+  }
+
+  public Event getParentEvent(Event event) {
+    return traceEventsGraph.getParentEvent(event);
+  }
+
+  public List<Entity> getParentEntities(Entity entity) {
+    return traceEntitiesGraph.getParentEntities(entity);
+  }
+
+  public List<Event> getChildrenEvents(Event event) {
+    return traceEventsGraph.getChildrenEvents(event);
+  }
+
+  public List<Entity> getChildrenEntities(Entity entity) {
+    return traceEntitiesGraph.getChildrenEntities(entity);
+  }
+
+  public Map<String, Entity> getEntityMap() {
+    return traceEntitiesGraph.getEntityMap();
+  }
+
+  public Map<ByteBuffer, Event> getEventMap() {
+    return traceEventsGraph.getEventMap();
+  }
+
+  public Map<ByteBuffer, ByteBuffer> getChildIdsToParentIds() {
+    return traceEventsGraph.getChildIdsToParentIds();
+  }
+
+  public Map<ByteBuffer, List<ByteBuffer>> getParentToChildEventIds() {
+    return traceEventsGraph.getParentToChildEventIds();
+  }
+
   public TraceEventsGraph getTraceEventsGraph() {
-    return this.traceEventsGraph;
+    return traceEventsGraph;
   }
 
   public TraceEntitiesGraph getTraceEntitiesGraph() {
-    return this.traceEntitiesGraph;
+    return traceEntitiesGraph;
   }
 }

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraph.java
@@ -11,8 +11,10 @@ public class StructuredTraceGraph {
   private TraceEventsGraph traceEventsGraph;
   private TraceEntitiesGraph traceEntitiesGraph;
 
+  private static StructuredTraceGraph graph;
+
   public static StructuredTraceGraph createGraph(StructuredTrace trace) {
-    StructuredTraceGraph graph = new StructuredTraceGraph();
+    graph = new StructuredTraceGraph();
     graph.traceEventsGraph = TraceEventsGraph.createGraph(trace);
     graph.traceEntitiesGraph = TraceEntitiesGraph.createGraph(trace);
 
@@ -20,14 +22,17 @@ public class StructuredTraceGraph {
   }
 
   public static StructuredTraceGraph reCreateTraceEventsGraph(StructuredTrace trace) {
-    StructuredTraceGraph graph = new StructuredTraceGraph();
+    if (null == graph) {
+      return createGraph(trace);
+    }
     graph.traceEventsGraph = TraceEventsGraph.createGraph(trace);
-
     return graph;
   }
 
   public static StructuredTraceGraph reCreateTraceEntitiesGraph(StructuredTrace trace) {
-    StructuredTraceGraph graph = new StructuredTraceGraph();
+    if (null == graph) {
+      return createGraph(trace);
+    }
     graph.traceEntitiesGraph = TraceEntitiesGraph.createGraph(trace);
 
     return graph;

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
@@ -1,6 +1,5 @@
 package org.hypertrace.core.datamodel.shared;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -10,7 +9,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.hypertrace.core.datamodel.Edge;
 import org.hypertrace.core.datamodel.Entity;
-import org.hypertrace.core.datamodel.Event;
 import org.hypertrace.core.datamodel.StructuredTrace;
 
 public class TraceEntitiesGraph {
@@ -20,7 +18,6 @@ public class TraceEntitiesGraph {
   private final Map<String, List<Entity>> childToParentEntities;
 
   /* these containers should be unmodifiable after initialization as we're exposing them via getters */
-  private Map<ByteBuffer, Event> eventMap;
   private Map<String, Entity> entityMap;
   private Set<Entity> rootEntities;
 

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
@@ -16,7 +16,6 @@ public class TraceEntitiesGraph {
   /* entity have many-to-many relationship */
   private final Map<String, List<Entity>> parentToChildrenEntities;
   private final Map<String, List<Entity>> childToParentEntities;
-  private final Set<String> childrenEntityIds;
 
   /* these containers should be unmodifiable after initialization as we're exposing them via getters */
   private final Map<String, Entity> entityMap;
@@ -25,7 +24,6 @@ public class TraceEntitiesGraph {
   private TraceEntitiesGraph() {
     this.childToParentEntities = new HashMap<>();
     this.parentToChildrenEntities = new HashMap<>();
-    this.childrenEntityIds = Sets.newHashSet();
     this.entityMap = Maps.newHashMap();
     this.rootEntities = Sets.newHashSet();
   }
@@ -84,12 +82,12 @@ public class TraceEntitiesGraph {
             .add(childEntity);
         childToParentEntities.computeIfAbsent(childEntity.getEntityId(), k -> new ArrayList<>())
             .add(parentEntity);
-        childrenEntityIds.add(childEntity.getEntityId());
       }
     }
   }
 
   private void processEntities(StructuredTrace trace) {
+    Set<String> childrenEntityIds = childToParentEntities.keySet();
     for (Entity entity : trace.getEntityList()) {
       entityMap.put(entity.getEntityId(), entity);
       if (!childrenEntityIds.contains(entity.getEntityId())) {

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEntitiesGraph.java
@@ -1,0 +1,111 @@
+package org.hypertrace.core.datamodel.shared;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Entity;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+
+public class TraceEntitiesGraph {
+
+  /* entity have many-to-many relationship */
+  private final Map<String, List<Entity>> parentToChildrenEntities;
+  private final Map<String, List<Entity>> childToParentEntities;
+
+  /* these containers should be unmodifiable after initialization as we're exposing them via getters */
+  private Map<ByteBuffer, Event> eventMap;
+  private Map<String, Entity> entityMap;
+  private Set<Entity> rootEntities;
+
+  private TraceEntitiesGraph() {
+    this.childToParentEntities = new HashMap<>();
+    this.parentToChildrenEntities = new HashMap<>();
+  }
+
+  /**
+   * Create the instance with or without the full traversal graph includesFullGraph    Includes
+   * computing the full traversal graph or not
+   */
+  public static TraceEntitiesGraph createGraph(StructuredTrace trace) {
+    TraceEntitiesGraph graph = new TraceEntitiesGraph();
+    graph.buildEntityMap(trace);
+    graph.buildParentChildRelationship(trace);
+    graph.buildRootEntities(trace);
+    return graph;
+  }
+
+  /**
+   * @return an immutable set containing the root entities
+   */
+  public Set<Entity> getRootEntities() {
+    return rootEntities;
+  }
+
+
+  public List<Entity> getParentEntities(Entity entity) {
+    return childToParentEntities.get(entity.getEntityId());
+  }
+
+
+  public List<Entity> getChildrenEntities(Entity entity) {
+    return parentToChildrenEntities.get(entity.getEntityId());
+  }
+
+  /**
+   * @return an immutable map of entity ids to entities
+   */
+  public Map<String, Entity> getEntityMap() {
+    return entityMap;
+  }
+
+  private void buildEntityMap(StructuredTrace trace) {
+    entityMap = trace.getEntityList().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(Entity::getEntityId, Function.identity(), (e1, e2) -> e2));
+  }
+
+  private void buildParentChildRelationship(StructuredTrace trace) {
+    List<Entity> entities = trace.getEntityList();
+
+    // return for now, we don't forsee this is to be null.
+    if (entities == null) {
+      return;
+    }
+
+    List<Edge> entityEdges = trace.getEntityEdgeList();
+    if (entityEdges != null) {
+      for (Edge entityEdge : trace.getEntityEdgeList()) {
+        Integer sourceIndex = entityEdge.getSrcIndex();
+        Integer targetIndex = entityEdge.getTgtIndex();
+        Entity parentEntity = entities.get(sourceIndex);
+        Entity childEntity = entities.get(targetIndex);
+        parentToChildrenEntities.computeIfAbsent(parentEntity.getEntityId(), k -> new ArrayList<>())
+            .add(childEntity);
+        childToParentEntities.computeIfAbsent(childEntity.getEntityId(), k -> new ArrayList<>())
+            .add(parentEntity);
+      }
+    }
+  }
+
+  private void buildRootEntities(StructuredTrace trace) {
+    // build the root entity ids
+    Set<String> rootEntityIds = trace.getEntityList().stream().map(Entity::getEntityId)
+        .collect(Collectors.toSet());
+
+    // remove all the children, and what's remaining are the entities without children
+    // we will consider these are roots, including the ones that are standalone
+    Set<String> childrenEntityIds = parentToChildrenEntities.values().stream()
+        .flatMap(l -> l.stream().map(Entity::getEntityId)).collect(Collectors.toSet());
+    rootEntityIds.removeAll(childrenEntityIds);
+
+    rootEntities = rootEntityIds.stream().map(entityMap::get)
+        .collect(Collectors.toUnmodifiableSet());
+  }
+}

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
@@ -75,8 +75,8 @@ public class TraceEventsGraph {
     List<Edge> eventEdges = trace.getEventEdgeList();
     if (eventEdges != null) {
       for (Edge edge : trace.getEventEdgeList()) {
-        Integer sourceIndex = edge.getSrcIndex();
-        Integer targetIndex = edge.getTgtIndex();
+        int sourceIndex = edge.getSrcIndex();
+        int targetIndex = edge.getTgtIndex();
         Event parentEvent = events.get(sourceIndex);
         Event childEvent = events.get(targetIndex);
         parentToChildrenEvents.computeIfAbsent(parentEvent.getEventId(), k -> new ArrayList<>())

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
@@ -1,0 +1,132 @@
+package org.hypertrace.core.datamodel.shared;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.hypertrace.core.datamodel.Edge;
+import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.core.datamodel.StructuredTrace;
+
+public class TraceEventsGraph {
+
+  /* there could be multiple roots for partial trace and incomplete instrumented app spans */
+  private final Map<ByteBuffer, List<Event>> parentToChildrenEvents;
+  private final Map<ByteBuffer, Event> childToParentEvents;
+
+
+  /* these containers should be unmodifiable after initialization as we're exposing them via getters */
+  private Map<ByteBuffer, Event> eventMap;
+  private Set<Event> rootEvents;
+
+  private TraceEventsGraph() {
+    this.childToParentEvents = new HashMap<>();
+    this.parentToChildrenEvents = new HashMap<>();
+  }
+
+  /**
+   * Create the instance with or without the full traversal graph includesFullGraph    Includes
+   * computing the full traversal graph or not
+   */
+  static TraceEventsGraph createGraph(StructuredTrace trace) {
+    TraceEventsGraph graph = new TraceEventsGraph();
+    graph.buildEventMap(trace);
+    graph.buildParentChildRelationship(trace);
+    graph.buildRootEvents(trace);
+    return graph;
+  }
+
+  /**
+   * @return an immutable set containing the root events
+   */
+  public Set<Event> getRootEvents() {
+    return rootEvents;
+  }
+
+
+  public Event getParentEvent(Event event) {
+    return childToParentEvents.get(event.getEventId());
+  }
+
+
+  public List<Event> getChildrenEvents(Event event) {
+    return parentToChildrenEvents.get(event.getEventId());
+  }
+
+  private void buildEventMap(StructuredTrace trace) {
+    eventMap = trace.getEventList().stream()
+        .collect(
+            Collectors.toUnmodifiableMap(Event::getEventId, Function.identity(), (e1, e2) -> e2));
+
+  }
+
+  private void buildParentChildRelationship(StructuredTrace trace) {
+    List<Event> events = trace.getEventList();
+    // there's no graph
+    if (events == null) {
+      return;
+    }
+
+    List<Edge> eventEdges = trace.getEventEdgeList();
+    if (eventEdges != null) {
+      for (Edge edge : trace.getEventEdgeList()) {
+        Integer sourceIndex = edge.getSrcIndex();
+        Integer targetIndex = edge.getTgtIndex();
+        Event parentEvent = events.get(sourceIndex);
+        Event childEvent = events.get(targetIndex);
+        parentToChildrenEvents.computeIfAbsent(parentEvent.getEventId(), k -> new ArrayList<>())
+            .add(childEvent);
+        childToParentEvents.put(childEvent.getEventId(), parentEvent);
+      }
+    }
+  }
+
+  private void buildRootEvents(StructuredTrace trace) {
+    // build the root event ids
+    Set<ByteBuffer> rootEventIds = trace.getEventList().stream().map(Event::getEventId)
+        .collect(Collectors.toSet());
+
+    // remove all the children, and what's remaining are the events without children
+    // we will consider these are roots, including the ones that are standalone
+    Set<ByteBuffer> childrenEventIds = parentToChildrenEvents.values().stream()
+        .flatMap(l -> l.stream().map(Event::getEventId)).collect(Collectors.toSet());
+    rootEventIds.removeAll(childrenEventIds);
+
+    rootEvents = rootEventIds.stream().map(eventMap::get).collect(Collectors.toUnmodifiableSet());
+  }
+
+  /**
+   * @return an immutable map of event ids to events
+   */
+  public Map<ByteBuffer, Event> getEventMap() {
+    return eventMap;
+  }
+
+  public Map<ByteBuffer, ByteBuffer> getChildIdsToParentIds() {
+    return childToParentEvents.entrySet().stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> getEventId(e.getValue())
+        ));
+  }
+
+  public Map<ByteBuffer, List<ByteBuffer>> getParentToChildEventIds() {
+    return parentToChildrenEvents.entrySet().stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> e.getValue().stream().map(this::getEventId).collect(Collectors.toList()))
+        );
+  }
+
+  private ByteBuffer getEventId(Event event) {
+    if (event == null) {
+      return null;
+    }
+    return event.getEventId();
+  }
+}

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceEventsGraph.java
@@ -20,8 +20,6 @@ public class TraceEventsGraph {
   /* there could be multiple roots for partial trace and incomplete instrumented app spans */
   private final Map<ByteBuffer, List<Event>> parentToChildrenEvents;
   private final Map<ByteBuffer, Event> childToParentEvents;
-  private final Set<ByteBuffer> childrenEventIds;
-
 
   /* these containers should be unmodifiable after initialization as we're exposing them via getters */
   private final Map<ByteBuffer, Event> eventMap;
@@ -30,7 +28,6 @@ public class TraceEventsGraph {
   private TraceEventsGraph() {
     this.childToParentEvents = new HashMap<>();
     this.parentToChildrenEvents = new HashMap<>();
-    this.childrenEventIds = Sets.newHashSet();
     this.eventMap = Maps.newHashMap();
     this.rootEvents = Sets.newHashSet();
   }
@@ -80,12 +77,13 @@ public class TraceEventsGraph {
         parentToChildrenEvents.computeIfAbsent(parentEvent.getEventId(), k -> new ArrayList<>())
             .add(childEvent);
         childToParentEvents.put(childEvent.getEventId(), parentEvent);
-        childrenEventIds.add(childEvent.getEventId());
+
       }
     }
   }
 
   private void processEvents(StructuredTrace trace) {
+    Set<ByteBuffer> childrenEventIds = childToParentEvents.keySet();
     for (Event event : trace.getEventList()) {
       eventMap.put(event.getEventId(), event);
       if (!childrenEventIds.contains(event.getEventId())) {

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
@@ -1,6 +1,8 @@
 package org.hypertrace.core.datamodel.shared;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -86,17 +88,15 @@ class StructuredTraceGraphTest {
         Sets.newHashSet(entities.get(rootIndex1), entities.get(rootIndex2));
 
     graph = StructuredTraceGraph.createGraph(trace);
-    TraceEntitiesGraph entitiesGraph = graph.getTraceEntitiesGraph();
-    TraceEventsGraph eventsGraph = graph.getTraceEventsGraph();
-    assertEquals(expectedRootEntities, entitiesGraph.getRootEntities());
-    assertEquals(expectedRootEvents, eventsGraph.getRootEvents());
-    assertEquals(events.get(sourceIdx1), eventsGraph.getParentEvent(events.get(targetIdx1)));
+    assertEquals(expectedRootEntities, graph.getRootEntities());
+    assertEquals(expectedRootEvents, graph.getRootEvents());
+    assertEquals(events.get(sourceIdx1), graph.getParentEvent(events.get(targetIdx1)));
     assertEquals(Lists.newArrayList(entities.get(sourceIdx1)),
-        entitiesGraph.getParentEntities(entities.get(targetIdx1)));
-    List<Entity> root1Children = entitiesGraph.getChildrenEntities(entities.get(rootIndex1));
+        graph.getParentEntities(entities.get(targetIdx1)));
+    List<Entity> root1Children = graph.getChildrenEntities(entities.get(rootIndex1));
     assertEquals(Lists.newArrayList(entities.get(targetIdx1)), root1Children);
-    assertEquals(expectedEventMap, eventsGraph.getEventMap());
-    assertEquals(childToParentIds, eventsGraph.getChildIdsToParentIds());
+    assertEquals(expectedEventMap, graph.getEventMap());
+    assertEquals(childToParentIds, graph.getChildIdsToParentIds());
   }
 
   private void setupEventAndEntityMocks(int totalEvent) {
@@ -160,15 +160,13 @@ class StructuredTraceGraphTest {
     StructuredTraceAssert.assertEntityEventEdges(trace);
 
     StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
-    TraceEntitiesGraph entitiesGraph = graph.getTraceEntitiesGraph();
-    TraceEventsGraph eventsGraph = graph.getTraceEventsGraph();
-    assertEquals(2, eventsGraph.getEventMap().size());
-    assertEquals(1, entitiesGraph.getRootEntities().size());
-    assertEquals(1, eventsGraph.getRootEvents().size());
-    assertTrue(eventsGraph.getChildIdsToParentIds().containsKey(e2.getEventId()));
-    assertTrue(eventsGraph.getParentToChildEventIds().containsKey(e1.getEventId()));
-    assertTrue(entitiesGraph.getParentEntities(entity2).contains(entity1));
-    assertEquals(e1, eventsGraph.getParentEvent(e2));
+    assertEquals(2, graph.getEventMap().size());
+    assertEquals(1, graph.getRootEntities().size());
+    assertEquals(1, graph.getRootEvents().size());
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertEquals(e1, graph.getParentEvent(e2));
   }
 
   private ByteBuffer generateRandomId() {
@@ -203,4 +201,96 @@ class StructuredTraceGraphTest {
     createGraph_shouldCreateCorrectGraph();
   }
 
+  @Test
+  void test_recreate_partialGraph() {
+    ByteBuffer traceId = generateRandomId();
+
+    String entityId1 = UUID.randomUUID().toString();
+    Event e1 = getEvent(generateRandomId(), entityId1);
+    Entity entity1 = getEntity(entityId1, "DOCKER_CONTAINER");
+    RawSpan rawSpan1 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+        .setEvent(e1).setEntityList(List.of(entity1)).build();
+
+    String entityId2 = UUID.randomUUID().toString();
+    Event e2 = getEvent(generateRandomId(), entityId2);
+    Entity entity2 = getEntity(entityId2, "K8S_POD");
+    RawSpan rawSpan2 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+        .setEvent(e2).setEntityList(List.of(entity2)).build();
+
+    // Make e2 as child of e1.
+    ByteBuffer eventId1 = e1.getEventId();
+    when(e2.getEventRefList()).thenReturn(Collections.singletonList(
+        EventRef.newBuilder().setEventId(eventId1).setRefType(EventRefType.CHILD_OF)
+            .setTraceId(traceId).build()));
+
+    StructuredTrace trace = StructuredTraceBuilder
+        .buildStructuredTraceFromRawSpans(List.of(rawSpan1, rawSpan2),
+            traceId,
+            CUSTOMER_ID);
+
+    assertEquals(traceId, trace.getTraceId());
+    assertEquals(CUSTOMER_ID, trace.getCustomerId());
+    assertEquals(2, trace.getEventList().size());
+    assertEquals(2, trace.getEntityList().size());
+
+    StructuredTraceAssert.assertEntityEntityEdge(trace);
+    StructuredTraceAssert.assertEventEventEdge(trace);
+    StructuredTraceAssert.assertEntityEventEdges(trace);
+
+    StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
+    assertEquals(2, graph.getEventMap().size());
+    assertEquals(1, graph.getRootEntities().size());
+    assertEquals(1, graph.getRootEvents().size());
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertEquals(e1, graph.getParentEvent(e2));
+
+    // add a new event and rebuild the event graph
+    String entityId3 = UUID.randomUUID().toString();
+    Event e3 = getEvent(generateRandomId(), entityId3);
+    Entity entity3 = getEntity(entityId3, "K8S_POD");
+    RawSpan rawSpan3 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+        .setEvent(e3).setEntityList(List.of(entity3)).build();
+    // e3 child of e1
+    when(e3.getEventRefList()).thenReturn(Collections.singletonList(
+        EventRef.newBuilder().setEventId(eventId1).setRefType(EventRefType.CHILD_OF)
+            .setTraceId(traceId).build()));
+
+    trace = StructuredTraceBuilder
+        .buildStructuredTraceFromRawSpans(List.of(rawSpan1, rawSpan2, rawSpan3),
+            traceId,
+            CUSTOMER_ID);
+    TraceEventsGraph traceEventsGraph = graph.getTraceEventsGraph();
+    TraceEntitiesGraph traceEntitiesGraph = graph.getTraceEntitiesGraph();
+
+    graph = StructuredTraceGraph.reCreateTraceEventsGraph(trace);
+    assertSame(traceEntitiesGraph, graph.getTraceEntitiesGraph());
+    assertNotSame(traceEventsGraph, graph.getTraceEventsGraph());
+    assertEquals(3, graph.getEventMap().size());
+    assertEquals(1, graph.getRootEntities().size());
+    assertEquals(1, graph.getRootEvents().size());
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e3.getEventId()));
+    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertEquals(1, graph.getChildrenEntities(entity1).size());
+    assertEquals(e1, graph.getParentEvent(e2));
+    assertEquals(e1, graph.getParentEvent(e3));
+
+    traceEventsGraph = graph.getTraceEventsGraph();
+    graph = StructuredTraceGraph.reCreateTraceEntitiesGraph(trace);
+    assertNotSame(traceEntitiesGraph, graph.getTraceEntitiesGraph());
+    assertSame(traceEventsGraph, graph.getTraceEventsGraph());
+    assertEquals(3, graph.getEventMap().size());
+    assertEquals(1, graph.getRootEntities().size());
+    assertEquals(1, graph.getRootEvents().size());
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(graph.getChildIdsToParentIds().containsKey(e3.getEventId()));
+    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertEquals(2, graph.getChildrenEntities(entity1).size());
+    assertEquals(e1, graph.getParentEvent(e2));
+    assertEquals(e1, graph.getParentEvent(e3));
+  }
 }

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
@@ -86,15 +86,17 @@ class StructuredTraceGraphTest {
         Sets.newHashSet(entities.get(rootIndex1), entities.get(rootIndex2));
 
     graph = StructuredTraceGraph.createGraph(trace);
-    assertEquals(expectedRootEntities, graph.getRootEntities());
-    assertEquals(expectedRootEvents, graph.getRootEvents());
-    assertEquals(events.get(sourceIdx1), graph.getParentEvent(events.get(targetIdx1)));
+    TraceEntitiesGraph entitiesGraph = graph.getTraceEntitiesGraph();
+    TraceEventsGraph eventsGraph = graph.getTraceEventsGraph();
+    assertEquals(expectedRootEntities, entitiesGraph.getRootEntities());
+    assertEquals(expectedRootEvents, eventsGraph.getRootEvents());
+    assertEquals(events.get(sourceIdx1), eventsGraph.getParentEvent(events.get(targetIdx1)));
     assertEquals(Lists.newArrayList(entities.get(sourceIdx1)),
-        graph.getParentEntities(entities.get(targetIdx1)));
-    List<Entity> root1Children = graph.getChildrenEntities(entities.get(rootIndex1));
+        entitiesGraph.getParentEntities(entities.get(targetIdx1)));
+    List<Entity> root1Children = entitiesGraph.getChildrenEntities(entities.get(rootIndex1));
     assertEquals(Lists.newArrayList(entities.get(targetIdx1)), root1Children);
-    assertEquals(expectedEventMap, graph.getEventMap());
-    assertEquals(childToParentIds, graph.getChildIdsToParentIds());
+    assertEquals(expectedEventMap, eventsGraph.getEventMap());
+    assertEquals(childToParentIds, eventsGraph.getChildIdsToParentIds());
   }
 
   private void setupEventAndEntityMocks(int totalEvent) {
@@ -158,13 +160,15 @@ class StructuredTraceGraphTest {
     StructuredTraceAssert.assertEntityEventEdges(trace);
 
     StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
-    assertEquals(2, graph.getEventMap().size());
-    assertEquals(1, graph.getRootEntities().size());
-    assertEquals(1, graph.getRootEvents().size());
-    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
-    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
-    assertTrue(graph.getParentEntities(entity2).contains(entity1));
-    assertEquals(e1, graph.getParentEvent(e2));
+    TraceEntitiesGraph entitiesGraph = graph.getTraceEntitiesGraph();
+    TraceEventsGraph eventsGraph = graph.getTraceEventsGraph();
+    assertEquals(2, eventsGraph.getEventMap().size());
+    assertEquals(1, entitiesGraph.getRootEntities().size());
+    assertEquals(1, eventsGraph.getRootEvents().size());
+    assertTrue(eventsGraph.getChildIdsToParentIds().containsKey(e2.getEventId()));
+    assertTrue(eventsGraph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    assertTrue(entitiesGraph.getParentEntities(entity2).contains(entity1));
+    assertEquals(e1, eventsGraph.getParentEvent(e2));
   }
 
   private ByteBuffer generateRandomId() {


### PR DESCRIPTION
Now that we are caching the graph in the enricher, this change gives finer control on what part of the graph to rebuild on changes in trace 