### PR TITLE
support for follow_from

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
@@ -365,11 +365,21 @@ public class StructuredTraceBuilder {
         //TODO: consider creating an empty event node?
         continue;
       }
-      //todo: Read about what can we do with FOLLOWS_FROM
-      //Ignore FOLLOWS_FROM for now.
-      if (!eventRef.getRefType().equals(EventRefType.CHILD_OF)) {
-        continue;
-      }
+
+      /*
+      For Follow from relationship:
+      * As, both the construct `child_of` and `follow_from` represent parent-child relation in common
+     * where in one case parent is interested in child span's result while in other case not.
+     *
+     * So, to support common behaviour, we will be establish link for `follow_from` as well.
+     * commenting out this part.
+     *
+     *      if (!eventRef.getRefType().equals(EventRefType.CHILD_OF)) {
+     *
+     *   continue;
+     * }
+     * Ref: https://github.com/hypertrace/hypertrace/issues/234.
+      */
 
       Event parentEvent = eventMap.get(eventRef.getEventId());
 

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
@@ -379,6 +379,7 @@ public class StructuredTraceBuilder {
      *   continue;
      * }
      * Ref: https://github.com/hypertrace/hypertrace/issues/234.
+     Note: Ideally, an event should have a single parent. It would be either via child_of or using follow_from.
      */
 
       Event parentEvent = eventMap.get(eventRef.getEventId());

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/trace/StructuredTraceBuilder.java
@@ -366,9 +366,9 @@ public class StructuredTraceBuilder {
         continue;
       }
 
-      /*
-      For Follow from relationship:
-      * As, both the construct `child_of` and `follow_from` represent parent-child relation in common
+    /*
+     * For Follow from relationship:
+     * As, both the construct `child_of` and `follow_from` represent parent-child relation in common
      * where in one case parent is interested in child span's result while in other case not.
      *
      * So, to support common behaviour, we will be establish link for `follow_from` as well.
@@ -379,7 +379,7 @@ public class StructuredTraceBuilder {
      *   continue;
      * }
      * Ref: https://github.com/hypertrace/hypertrace/issues/234.
-      */
+     */
 
       Event parentEvent = eventMap.get(eventRef.getEventId());
 

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/StructuredTraceGraphTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+
 class StructuredTraceGraphTest {
 
   private static final String CUSTOMER_ID = "customer_id";
@@ -139,34 +140,50 @@ class StructuredTraceGraphTest {
     RawSpan rawSpan2 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
         .setEvent(e2).setEntityList(List.of(entity2)).build();
 
+    String entityId3 = UUID.randomUUID().toString();
+    Event e3 = getEvent(generateRandomId(), entityId3);
+    Entity entity3 = getEntity(entityId3, "DAEMONSET");
+    RawSpan rawSpan3 = RawSpan.newBuilder().setCustomerId(CUSTOMER_ID).setTraceId(traceId)
+            .setEvent(e3).setEntityList(List.of(entity3)).build();
+
     // Make e2 as child of e1.
     ByteBuffer eventId1 = e1.getEventId();
     when(e2.getEventRefList()).thenReturn(Collections.singletonList(
         EventRef.newBuilder().setEventId(eventId1).setRefType(EventRefType.CHILD_OF)
             .setTraceId(traceId).build()));
 
+    //Making e3 as child of e2, follow_from construct
+    ByteBuffer eventId2 = e2.getEventId();
+    when(e3.getEventRefList()).thenReturn(Collections.singletonList(
+            EventRef.newBuilder().setEventId(eventId2).setRefType(EventRefType.FOLLOWS_FROM)
+                    .setTraceId(traceId).build()));
+
     StructuredTrace trace = StructuredTraceBuilder
-        .buildStructuredTraceFromRawSpans(List.of(rawSpan1, rawSpan2),
+        .buildStructuredTraceFromRawSpans(List.of(rawSpan1, rawSpan2,rawSpan3),
             traceId,
             CUSTOMER_ID);
 
     assertEquals(traceId, trace.getTraceId());
     assertEquals(CUSTOMER_ID, trace.getCustomerId());
-    assertEquals(2, trace.getEventList().size());
-    assertEquals(2, trace.getEntityList().size());
+    assertEquals(3, trace.getEventList().size());
+    assertEquals(3, trace.getEntityList().size());
 
     StructuredTraceAssert.assertEntityEntityEdge(trace);
     StructuredTraceAssert.assertEventEventEdge(trace);
     StructuredTraceAssert.assertEntityEventEdges(trace);
 
     StructuredTraceGraph graph = StructuredTraceGraph.createGraph(trace);
-    assertEquals(2, graph.getEventMap().size());
+    assertEquals(3, graph.getEventMap().size());
     assertEquals(1, graph.getRootEntities().size());
     assertEquals(1, graph.getRootEvents().size());
-    assertTrue(graph.getChildIdsToParentIds().containsKey(e2.getEventId()));
-    assertTrue(graph.getParentToChildEventIds().containsKey(e1.getEventId()));
+    Map<ByteBuffer,ByteBuffer> childIdToParentIds = graph.getChildIdsToParentIds();
+    Map<ByteBuffer,List<ByteBuffer>> parentToChildEventIds = graph.getParentToChildEventIds();
+    assertTrue(childIdToParentIds.containsKey(e2.getEventId()) && childIdToParentIds.containsKey(e3.getEventId()));
+    assertTrue(parentToChildEventIds.containsKey(e1.getEventId()) && parentToChildEventIds.containsKey(e2.getEventId()));
     assertTrue(graph.getParentEntities(entity2).contains(entity1));
+    assertTrue(graph.getParentEntities(entity3).contains(entity2));
     assertEquals(e1, graph.getParentEvent(e2));
+    assertEquals(e2, graph.getParentEvent(e3));
   }
 
   private ByteBuffer generateRandomId() {


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->
Adding support for the follow_from construct for building parent-child relationship. (Ref: https://github.com/hypertrace/hypertrace/issues/250)

needed for  https://github.com/hypertrace/hypertrace-ingester/pull/208




### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

