### PR TITLE
chore: update vulnerable transitive dependency

### DIFF
--- a/data-model/build.gradle.kts
+++ b/data-model/build.gradle.kts
@@ -12,6 +12,11 @@ tasks.test {
 
 dependencies {
   api("org.apache.avro:avro:1.10.2")
+  constraints {
+    api("org.apache.commons:commons-compress:1.21") {
+      because("Multiple vulnerabilities in avro-declared version")
+    }
+  }
   api("commons-codec:commons-codec:1.14")
   api("io.micrometer:micrometer-core:1.5.3")
 


### PR DESCRIPTION
## Description
A number of CVEs fixed in 1.21 that started getting flagged, such as https://snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316639