### PR TITLE
adding getBooleanAttribute method to data-model(TraceAttributeUtils)

### DIFF
--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtils.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtils.java
@@ -14,6 +14,9 @@ public class TraceAttributeUtils {
         && trace.getAttributes().getAttributeMap() != null
         && trace.getAttributes().getAttributeMap().containsKey(attribute);
   }
+  public static boolean getBooleanAttribute(StructuredTrace trace, String attribute) {
+    return Boolean.parseBoolean(getStringAttribute(trace, attribute));
+  }
 
   public static String getStringAttribute(StructuredTrace trace, String attribute) {
     if (trace.getAttributes() == null) {

--- a/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtils.java
+++ b/data-model/src/main/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtils.java
@@ -14,6 +14,7 @@ public class TraceAttributeUtils {
         && trace.getAttributes().getAttributeMap() != null
         && trace.getAttributes().getAttributeMap().containsKey(attribute);
   }
+
   public static boolean getBooleanAttribute(StructuredTrace trace, String attribute) {
     return Boolean.parseBoolean(getStringAttribute(trace, attribute));
   }

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
@@ -1,7 +1,9 @@
 package org.hypertrace.core.datamodel.shared;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,5 +36,33 @@ public class TraceAttributeUtilsTest {
     assertEquals(
         List.of("somevalue1", "somevalue2"),
         TraceAttributeUtils.getListAttribute(mockTrace, "someattribute"));
+  }
+
+  @Test
+  public void getStringAttributeTest() {
+    StructuredTrace mockTrace = mock(StructuredTrace.class);
+    assertNull(TraceAttributeUtils.getStringAttribute(mockTrace, "someattribute"));
+
+    Map<String, AttributeValue> attributeMap = new HashMap<>();
+    when(mockTrace.getAttributes())
+        .thenReturn(Attributes.newBuilder().setAttributeMap(attributeMap).build());
+    assertNull(TraceAttributeUtils.getStringAttribute(mockTrace, "someattribute"));
+
+    attributeMap.put("someattribute", AttributeValue.newBuilder().setValue("somevalue").build());
+    assertEquals("somevalue", TraceAttributeUtils.getStringAttribute(mockTrace, "someattribute"));
+  }
+
+  @Test
+  public void getBooleanAttributeTest() {
+    StructuredTrace mockTrace = mock(StructuredTrace.class);
+    assertFalse(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someattribute"));
+
+    Map<String, AttributeValue> attributeMap = new HashMap<>();
+    when(mockTrace.getAttributes())
+        .thenReturn(Attributes.newBuilder().setAttributeMap(attributeMap).build());
+    assertFalse(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someattribute"));
+
+    attributeMap.put("someattribute", AttributeValue.newBuilder().setValue("true").build());
+    assertTrue(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someattribute"));
   }
 }

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
@@ -65,8 +65,7 @@ public class TraceAttributeUtilsTest {
     attributeMap.put("someattribute", AttributeValue.newBuilder().setValue("true").build());
     assertTrue(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someattribute"));
 
-    attributeMap.put(
-        "someOtherAttribute", AttributeValue.newBuilder().setValue("xyz").build());
+    attributeMap.put("someOtherAttribute", AttributeValue.newBuilder().setValue("xyz").build());
     assertFalse(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someOtherAttribute"));
 
     attributeMap.put("otherAttribute", AttributeValue.newBuilder().setValue("").build());

--- a/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
+++ b/data-model/src/test/java/org/hypertrace/core/datamodel/shared/TraceAttributeUtilsTest.java
@@ -64,5 +64,12 @@ public class TraceAttributeUtilsTest {
 
     attributeMap.put("someattribute", AttributeValue.newBuilder().setValue("true").build());
     assertTrue(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someattribute"));
+
+    attributeMap.put(
+        "someOtherAttribute", AttributeValue.newBuilder().setValue("xyz").build());
+    assertFalse(TraceAttributeUtils.getBooleanAttribute(mockTrace, "someOtherAttribute"));
+
+    attributeMap.put("otherAttribute", AttributeValue.newBuilder().setValue("").build());
+    assertFalse(TraceAttributeUtils.getBooleanAttribute(mockTrace, "otherAttribute"));
   }
 }


### PR DESCRIPTION
## Description
Please include a summary of the change, motivation and context.

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Make sure that you have documented corresponding changes in this repository or [hypertrace docs repo](https://github.com/hypertrace/hypertrace-docs-website) if required.

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
